### PR TITLE
fix: handle A1111-style metadata from "parameters" key

### DIFF
--- a/nodes/modules/pnginfo_util.py
+++ b/nodes/modules/pnginfo_util.py
@@ -58,6 +58,11 @@ def get_prompt(img:Image.Image) -> dict[str, str]:
     # print("TYPE: nai")
     (prompt['positive'], prompt['negative']) = _get_prompt_nai(items)
 
+  elif "parameters" in items:
+    # print("assuming A1111-style parameters")
+    comment = items["parameters"]
+    (prompt['positive'], prompt['negative']) = _get_prompt_a1111(comment)
+
   return prompt
 
 # 


### PR DESCRIPTION
### Japanese Summary (Skippable)

カスタムノード "D2 Load Image" において、A1111製の画像からプロンプトが読み込まれませんでした。
原因は（少なくとも当環境では）A1111製の画像を検知しないことが原因のようでした。
この変更で、当該フォーマットの画像のプロンプトが検知されるようにしました。
プルリクエストの最後に、変更適用前と適用後の生成時のスクリーンショットを添付しています。
Show Text ノードに文字の表示が確認できます。

### Bug Description

Currently, `D2 Load Image` fails to extract prompt metadata from images generated by the latest AUTOMATIC1111 (A1111).

This happens because the node only checks for specific metadata sources (such as EXIF comments), and does not account for the `"parameters"` key used by A1111 in the PNG text chunk.

### Expected Behavior

When loading an image created by A1111, the positive and negative prompts should be correctly extracted and propagated to the output.

### Cause

The parser does not check for `"parameters"` key in the `items` dictionary, where A1111 embeds prompt metadata (as a plaintext blob).

### Fix Summary

This PR adds support for A1111-style metadata by checking for the `"parameters"` key and parsing it accordingly using the existing `_get_prompt_a1111()` function.

### Testing Conditions

- **Tested version of D2-nodes-ComfyUI**: [`1db87ab`](https://github.com/da2el-ai/D2-nodes-ComfyUI/commit/1db87ab8ad425579a11584119f94c6c616425e65)  
  (latest revision as of 2025/04/20)
- **Test image**: Generated by [stable-diffusion-webui v1.10.1](https://github.com/AUTOMATIC1111/stable-diffusion-webui)

---

### Before the Fix

> In the previous version, prompt metadata was not displayed.  
> The `String` node remained empty when loading A1111-generated images.

![comp_before](https://github.com/user-attachments/assets/19f73481-b217-407b-a15a-ff23e925b837)

---

### After the Fix

> After applying the fix, the positive prompt metadata is correctly parsed and displayed.  
> The `String` node now shows the expected prompt values from the image metadata.

![comp_after](https://github.com/user-attachments/assets/42d31d87-a857-4cc5-9964-f31b9745a0f7)
